### PR TITLE
Delete return in nextturn function to fix bug

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -14,10 +14,10 @@ class Game {
 
   nextTurn() {
     if(this.playerTurn === this.player1) {
-    return this.playerTurn = this.player2;
+    this.playerTurn = this.player2;
     nextPlayerTurn.innerText = `It's ${game.playerTurn.token}'s turn!`
     } else {
-   return this.playerTurn = this.player1;
+   this.playerTurn = this.player1;
     nextPlayerTurn.innerText = `It's ${game.playerTurn.token}'s turn!`
     }
   }


### PR DESCRIPTION
What (if any) features are you implementing?

-None

What (if anything) did you refactor?

- removed the keyword ``return`` from my nextturn function because it was not toggling the innertext message properly because the function was stopping before it ever got to the next user. 